### PR TITLE
Add logging options and clear streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,36 +4,17 @@ import {
   stdSerializers
 } from 'browser-bunyan'
 
-const log = createLogger({
-  name: 'formatted',
-  streams: [{
-      level: 'info',
-      stream: new ConsoleFormattedStream()
-    },
-    {
-      level: 'warn',
-      stream: new ConsoleFormattedStream()
-    },
-    {
-      level: 'error',
-      stream: new ConsoleFormattedStream()
-    },
-    {
-      level: 'debug',
-      stream: new ConsoleFormattedStream()
-    },
-    {
-      level: 'fatal',
-      stream: new ConsoleFormattedStream()
-    }
-  ],
+const log = ({ name, level }) = createLogger({
+  name: name,
+  level: level,
+  stream: new ConsoleFormattedStream(),
   serializers: stdSerializers,
   src: true
 })
 
 const logger = {
   install(Vue, options) {
-    Vue.prototype.$log = log
+    Vue.prototype.$log = log(options)
   }
 }
 


### PR DESCRIPTION
The name "formatted" is a little weird for the loggin name, just pass it as an option. I was not sure but I don't think you need a formatter for every log level. If you log 'debug' everything above it will print as wel. With level option it's easier to disable it in production.